### PR TITLE
Merge kineo master

### DIFF
--- a/js/adapt-article-reveal.js
+++ b/js/adapt-article-reveal.js
@@ -117,14 +117,13 @@ var ArticleRevealView = Backbone.View.extend({
     },
 
     toggleisVisible: function(view) {
-  		var allComponents = this.model.findDescendants('components');
-  		  allComponents.each(function(component) {
-  				component.set({
-                    '_isVisible':view
-                },{
-                    pluginName:"_articleReveal"
-                });
-  		  });
+        var allComponents = this.model.findDescendants('components');
+        allComponents.each(function(component) {
+            component.setLocking("_isVisible", false);
+            component.set('_isVisible', view, {
+                pluginName:"_articleReveal"
+            });
+        });
     },
     
     preventDrag: function() {


### PR DESCRIPTION
Used locking on the _isVisible attribute so the value only changes when all extension agree. To fix an issue where components within an article reveal where clickable in the PLP when closed, as trickle had changed the attribute value to make it looks as if it was visible.